### PR TITLE
chore: rename functions

### DIFF
--- a/policyenforcer.go
+++ b/policyenforcer.go
@@ -23,7 +23,7 @@ import (
 )
 
 // registeredPolicyEnforcers saves the registered policy enforcer factories.
-var registeredPolicyEnforcers map[string]func(CreatePolicyEnforcerOptions) (PolicyEnforcer, error)
+var registeredPolicyEnforcers map[string]func(NewPolicyEnforcerOptions) (PolicyEnforcer, error)
 
 // ValidationReport describes the results of verifying an artifact and its
 // nested artifacts by available verifiers.
@@ -57,9 +57,9 @@ type PolicyEnforcer interface {
 	Evaluate(ctx context.Context, artifactReports []*ValidationReport) (bool, error)
 }
 
-// CreatePolicyEnforcerOptions represents the options to create a policy
-// enforcer plugin.
-type CreatePolicyEnforcerOptions struct {
+// NewPolicyEnforcerOptions represents the options to create a policy enforcer
+// plugin.
+type NewPolicyEnforcerOptions struct {
 	// Name is unique identifier of a policy enforcer instance. Required.
 	Name string
 
@@ -73,7 +73,7 @@ type CreatePolicyEnforcerOptions struct {
 }
 
 // RegisterPolicyEnforcer registers a policy enforcer factory to the system.
-func RegisterPolicyEnforcer(policyEnforcerType string, create func(CreatePolicyEnforcerOptions) (PolicyEnforcer, error)) {
+func RegisterPolicyEnforcer(policyEnforcerType string, create func(NewPolicyEnforcerOptions) (PolicyEnforcer, error)) {
 	if policyEnforcerType == "" {
 		panic("policy enforcer type cannot be empty")
 	}
@@ -81,7 +81,7 @@ func RegisterPolicyEnforcer(policyEnforcerType string, create func(CreatePolicyE
 		panic("policy enforcer factory cannot be nil")
 	}
 	if registeredPolicyEnforcers == nil {
-		registeredPolicyEnforcers = make(map[string]func(CreatePolicyEnforcerOptions) (PolicyEnforcer, error))
+		registeredPolicyEnforcers = make(map[string]func(NewPolicyEnforcerOptions) (PolicyEnforcer, error))
 	}
 	if _, registered := registeredPolicyEnforcers[policyEnforcerType]; registered {
 		panic(fmt.Sprintf("policy enforcer factory type %s already registered", policyEnforcerType))
@@ -89,9 +89,9 @@ func RegisterPolicyEnforcer(policyEnforcerType string, create func(CreatePolicyE
 	registeredPolicyEnforcers[policyEnforcerType] = create
 }
 
-// CreatePolicyEnforcer creates a policy enforcer instance if it belongs to a
+// NewPolicyEnforcer creates a policy enforcer instance if it belongs to a
 // registered type.
-func CreatePolicyEnforcer(opts CreatePolicyEnforcerOptions) (PolicyEnforcer, error) {
+func NewPolicyEnforcer(opts NewPolicyEnforcerOptions) (PolicyEnforcer, error) {
 	if opts.Name == "" || opts.Type == "" {
 		return nil, fmt.Errorf("name or type is not provided in the policy enforcer options")
 	}

--- a/policyenforcer_test.go
+++ b/policyenforcer_test.go
@@ -17,7 +17,7 @@ package ratify
 
 import "testing"
 
-func createPolicyEnforcer(_ CreatePolicyEnforcerOptions) (PolicyEnforcer, error) {
+func newPolicyEnforcer(_ NewPolicyEnforcerOptions) (PolicyEnforcer, error) {
 	return nil, nil
 }
 
@@ -27,7 +27,7 @@ func TestRegisterPolicyEnforcer_EmptyType_Panic(t *testing.T) {
 			t.Errorf("Expected to panic")
 		}
 	}()
-	RegisterPolicyEnforcer("", createPolicyEnforcer)
+	RegisterPolicyEnforcer("", newPolicyEnforcer)
 }
 
 func TestRegisterPolicyEnforcer_NilFactory_Panic(t *testing.T) {
@@ -44,31 +44,31 @@ func TestRegisterPolicyEnforcer_DuplicateFactory_Panic(t *testing.T) {
 		if r := recover(); r == nil {
 			t.Errorf("Expected to panic")
 		}
-		registeredPolicyEnforcers = make(map[string]func(CreatePolicyEnforcerOptions) (PolicyEnforcer, error))
+		registeredPolicyEnforcers = make(map[string]func(NewPolicyEnforcerOptions) (PolicyEnforcer, error))
 	}()
-	RegisterPolicyEnforcer(test, createPolicyEnforcer)
-	RegisterPolicyEnforcer(test, createPolicyEnforcer)
+	RegisterPolicyEnforcer(test, newPolicyEnforcer)
+	RegisterPolicyEnforcer(test, newPolicyEnforcer)
 }
 
-func TestCreatePolicyEnforcer(t *testing.T) {
-	RegisterPolicyEnforcer(test, createPolicyEnforcer)
+func TestNewPolicyEnforcer(t *testing.T) {
+	RegisterPolicyEnforcer(test, newPolicyEnforcer)
 	defer func() {
-		registeredPolicyEnforcers = make(map[string]func(CreatePolicyEnforcerOptions) (PolicyEnforcer, error))
+		registeredPolicyEnforcers = make(map[string]func(NewPolicyEnforcerOptions) (PolicyEnforcer, error))
 	}()
 
 	tests := []struct {
 		name        string
-		opts        CreatePolicyEnforcerOptions
+		opts        NewPolicyEnforcerOptions
 		expectedErr bool
 	}{
 		{
 			name:        "no type provided",
-			opts:        CreatePolicyEnforcerOptions{},
+			opts:        NewPolicyEnforcerOptions{},
 			expectedErr: true,
 		},
 		{
 			name: "non-registered type",
-			opts: CreatePolicyEnforcerOptions{
+			opts: NewPolicyEnforcerOptions{
 				Name: test,
 				Type: "non-registered",
 			},
@@ -76,7 +76,7 @@ func TestCreatePolicyEnforcer(t *testing.T) {
 		},
 		{
 			name: "registered type",
-			opts: CreatePolicyEnforcerOptions{
+			opts: NewPolicyEnforcerOptions{
 				Name: test,
 				Type: test,
 			},
@@ -86,7 +86,7 @@ func TestCreatePolicyEnforcer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := CreatePolicyEnforcer(test.opts)
+			_, err := NewPolicyEnforcer(test.opts)
 			if test.expectedErr != (err != nil) {
 				t.Errorf("Expected error: %v, got: %v", test.expectedErr, err)
 			}

--- a/store.go
+++ b/store.go
@@ -23,7 +23,7 @@ import (
 )
 
 // registeredStores saves the registered store factories.
-var registeredStores map[string]func(CreateStoreOptions) (Store, error)
+var registeredStores map[string]func(NewStoreOptions) (Store, error)
 
 // Store is an interface that defines methods to query the graph of supply chain
 // content including its related content
@@ -50,13 +50,13 @@ type Store interface {
 	FetchImageManifest(ctx context.Context, repo string, desc ocispec.Descriptor) (*ocispec.Manifest, error)
 }
 
-// CreateStoreOptions represents the options to create a store.
-type CreateStoreOptions struct {
+// NewStoreOptions represents the options to create a store.
+type NewStoreOptions struct {
 	// Name is unique identifier of a store instance. Required.
 	Name string
 
 	// Type represents a specific implementation of stores. Required.
-	// Note: there could be multiple stores of the same type with different 
+	// Note: there could be multiple stores of the same type with different
 	//       names.
 	Type string
 
@@ -65,7 +65,7 @@ type CreateStoreOptions struct {
 }
 
 // RegisterStore registers a store factory to the system.
-func RegisterStore(storeType string, create func(CreateStoreOptions) (Store, error)) {
+func RegisterStore(storeType string, create func(NewStoreOptions) (Store, error)) {
 	if storeType == "" {
 		panic("store type cannot be empty")
 	}
@@ -73,7 +73,7 @@ func RegisterStore(storeType string, create func(CreateStoreOptions) (Store, err
 		panic("store factory cannot be nil")
 	}
 	if registeredStores == nil {
-		registeredStores = make(map[string]func(CreateStoreOptions) (Store, error))
+		registeredStores = make(map[string]func(NewStoreOptions) (Store, error))
 	}
 	if _, registered := registeredStores[storeType]; registered {
 		panic(fmt.Sprintf("store factory type %s already registered", storeType))
@@ -81,8 +81,8 @@ func RegisterStore(storeType string, create func(CreateStoreOptions) (Store, err
 	registeredStores[storeType] = create
 }
 
-// CreateStore creates a store instance if it belongs to a registered type.
-func CreateStore(opts CreateStoreOptions) (Store, error) {
+// NewStore creates a store instance if it belongs to a registered type.
+func NewStore(opts NewStoreOptions) (Store, error) {
 	if opts.Name == "" || opts.Type == "" {
 		return nil, fmt.Errorf("name or type is not provided in the store options")
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -17,7 +17,7 @@ package ratify
 
 import "testing"
 
-func createStore(_ CreateStoreOptions) (Store, error) {
+func newStore(_ NewStoreOptions) (Store, error) {
 	return nil, nil
 }
 
@@ -27,7 +27,7 @@ func TestRegisterStore_EmptyType_Panic(t *testing.T) {
 			t.Errorf("Expected to panic")
 		}
 	}()
-	RegisterStore("", createStore)
+	RegisterStore("", newStore)
 }
 
 func TestRegisterStore_NilFactory_Panic(t *testing.T) {
@@ -44,31 +44,31 @@ func TestRegisterStore_DuplicateFactory_Panic(t *testing.T) {
 		if r := recover(); r == nil {
 			t.Errorf("Expected to panic")
 		}
-		registeredStores = make(map[string]func(CreateStoreOptions) (Store, error))
+		registeredStores = make(map[string]func(NewStoreOptions) (Store, error))
 	}()
-	RegisterStore(test, createStore)
-	RegisterStore(test, createStore)
+	RegisterStore(test, newStore)
+	RegisterStore(test, newStore)
 }
 
-func TestCreateStore(t *testing.T) {
-	RegisterStore(test, createStore)
+func TestNewStore(t *testing.T) {
+	RegisterStore(test, newStore)
 	defer func() {
-		registeredStores = make(map[string]func(CreateStoreOptions) (Store, error))
+		registeredStores = make(map[string]func(NewStoreOptions) (Store, error))
 	}()
 
 	tests := []struct {
 		name        string
-		opts        CreateStoreOptions
+		opts        NewStoreOptions
 		expectedErr bool
 	}{
 		{
 			name:        "no type provided",
-			opts:        CreateStoreOptions{},
+			opts:        NewStoreOptions{},
 			expectedErr: true,
 		},
 		{
 			name: "non-registered type",
-			opts: CreateStoreOptions{
+			opts: NewStoreOptions{
 				Name: test,
 				Type: "non-registered",
 			},
@@ -76,7 +76,7 @@ func TestCreateStore(t *testing.T) {
 		},
 		{
 			name: "registered type",
-			opts: CreateStoreOptions{
+			opts: NewStoreOptions{
 				Name: test,
 				Type: test,
 			},
@@ -86,7 +86,7 @@ func TestCreateStore(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := CreateStore(test.opts)
+			_, err := NewStore(test.opts)
 			if test.expectedErr != (err != nil) {
 				t.Errorf("Expected error: %v, got: %v", test.expectedErr, err)
 			}

--- a/verifier.go
+++ b/verifier.go
@@ -23,7 +23,7 @@ import (
 )
 
 // registeredVerifiers saves the registered verifier factories.
-var registeredVerifiers map[string]func(CreateVerifierOptions) (Verifier, error)
+var registeredVerifiers map[string]func(NewVerifierOptions) (Verifier, error)
 
 // Verifier is an interface that defines methods to verify an artifact
 // associated with a subject.
@@ -60,8 +60,8 @@ type VerificationResult struct {
 	Detail any
 }
 
-// CreateVerifierOptions represents the options to create a verifier.
-type CreateVerifierOptions struct {
+// NewVerifierOptions represents the options to create a verifier.
+type NewVerifierOptions struct {
 	// Name is the unique identifier of a verifier instantce. Required.
 	Name string
 
@@ -75,7 +75,7 @@ type CreateVerifierOptions struct {
 }
 
 // RegisterVerifier registers a verifier factory to the system.
-func RegisterVerifier(verifierType string, create func(CreateVerifierOptions) (Verifier, error)) {
+func RegisterVerifier(verifierType string, create func(NewVerifierOptions) (Verifier, error)) {
 	if verifierType == "" {
 		panic("verifier type cannot be empty")
 	}
@@ -83,7 +83,7 @@ func RegisterVerifier(verifierType string, create func(CreateVerifierOptions) (V
 		panic("verifier factory cannot be nil")
 	}
 	if registeredVerifiers == nil {
-		registeredVerifiers = make(map[string]func(CreateVerifierOptions) (Verifier, error))
+		registeredVerifiers = make(map[string]func(NewVerifierOptions) (Verifier, error))
 	}
 	if _, registered := registeredVerifiers[verifierType]; registered {
 		panic(fmt.Sprintf("verifier factory named %s already registered", verifierType))
@@ -91,8 +91,8 @@ func RegisterVerifier(verifierType string, create func(CreateVerifierOptions) (V
 	registeredVerifiers[verifierType] = create
 }
 
-// CreateVerifier creates a verifier instance if it belongs to a registered type.
-func CreateVerifier(opts CreateVerifierOptions) (Verifier, error) {
+// NewVerifier creates a verifier instance if it belongs to a registered type.
+func NewVerifier(opts NewVerifierOptions) (Verifier, error) {
 	if opts.Name == "" || opts.Type == "" {
 		return nil, fmt.Errorf("name or type is not provided in the verifier options")
 	}

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -19,7 +19,7 @@ import "testing"
 
 const test = "test"
 
-func createVerifier(_ CreateVerifierOptions) (Verifier, error) {
+func newVerifier(_ NewVerifierOptions) (Verifier, error) {
 	return nil, nil
 }
 
@@ -29,7 +29,7 @@ func TestRegisterVerifier_EmptyType_Panic(t *testing.T) {
 			t.Errorf("Expected to panic")
 		}
 	}()
-	RegisterVerifier("", createVerifier)
+	RegisterVerifier("", newVerifier)
 }
 
 func TestRegisterVerifier_NilFactory_Panic(t *testing.T) {
@@ -46,31 +46,31 @@ func TestRegisterVerifier_DuplicateFactory_Panic(t *testing.T) {
 		if r := recover(); r == nil {
 			t.Errorf("Expected to panic")
 		}
-		registeredVerifiers = make(map[string]func(CreateVerifierOptions) (Verifier, error))
+		registeredVerifiers = make(map[string]func(NewVerifierOptions) (Verifier, error))
 	}()
-	RegisterVerifier(test, createVerifier)
-	RegisterVerifier(test, createVerifier)
+	RegisterVerifier(test, newVerifier)
+	RegisterVerifier(test, newVerifier)
 }
 
-func TestCreateVerifier(t *testing.T) {
-	RegisterVerifier(test, createVerifier)
+func TestNewVerifier(t *testing.T) {
+	RegisterVerifier(test, newVerifier)
 	defer func() {
-		registeredVerifiers = make(map[string]func(CreateVerifierOptions) (Verifier, error))
+		registeredVerifiers = make(map[string]func(NewVerifierOptions) (Verifier, error))
 	}()
 
 	tests := []struct {
 		name        string
-		opts        CreateVerifierOptions
+		opts        NewVerifierOptions
 		expectedErr bool
 	}{
 		{
 			name:        "no type provided",
-			opts:        CreateVerifierOptions{},
+			opts:        NewVerifierOptions{},
 			expectedErr: true,
 		},
 		{
 			name: "non-registered type",
-			opts: CreateVerifierOptions{
+			opts: NewVerifierOptions{
 				Name: test,
 				Type: "non-registered",
 			},
@@ -78,7 +78,7 @@ func TestCreateVerifier(t *testing.T) {
 		},
 		{
 			name: "registered type",
-			opts: CreateVerifierOptions{
+			opts: NewVerifierOptions{
 				Name: test,
 				Type: test,
 			},
@@ -88,7 +88,7 @@ func TestCreateVerifier(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := CreateVerifier(test.opts)
+			_, err := NewVerifier(test.opts)
 			if test.expectedErr != (err != nil) {
 				t.Errorf("Expected error: %v, got: %v", test.expectedErr, err)
 			}


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
Rename functions and options that are defined for creating store/verifier/policyEnforcer. 
The previous names are in the form Create[xxx] or Create[xxx]Options, will be renamed to New[xxx] and New[xxx]Options to follow the golang naming convention.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

No tests required.

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
