### PR TITLE
feat: update verifier interface to take subjectDesc

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -193,10 +193,10 @@ func (e *Executor) verifyArtifact(ctx context.Context, subject string, subjectDe
 			continue
 		}
 		verifierReport, err := verifier.Verify(ctx, &VerifyOptions{
-			ArtifactStore:     e.Store,
-			Subject:           subject,
-			SubjectDescriptor: subjectDesc,
-			Artifact:          artifact,
+			Store:              e.Store,
+			Subject:            subject,
+			SubjectDescriptor:  subjectDesc,
+			ArtifactDescriptor: artifact,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to verify artifact %s with verifier %s: %w", subject, verifier.Name(), err)

--- a/executor_test.go
+++ b/executor_test.go
@@ -59,11 +59,14 @@ func (m *mockVerifier) Verifiable(_ ocispec.Descriptor) bool {
 	return m.verifiable
 }
 
-func (m *mockVerifier) Verify(ctx context.Context, store Store, subject string, artifact ocispec.Descriptor) (*VerificationResult, error) {
+func (m *mockVerifier) Verify(ctx context.Context, opts *VerifyOptions) (*VerificationResult, error) {
+	if opts.SubjectDescriptor.Digest == "" {
+		return nil, errors.New("subject digest not set")
+	}
 	if m.verifyResult == nil {
 		return &VerificationResult{}, errors.New("verify result not initialized")
 	}
-	if result, ok := m.verifyResult[artifact.Digest.String()]; ok {
+	if result, ok := m.verifyResult[opts.Artifact.Digest.String()]; ok {
 		return result, nil
 	}
 	return &VerificationResult{}, nil
@@ -538,28 +541,28 @@ func sameVerifierReport(report1, report2 *VerificationResult) bool {
 
 func TestValidateExecutorSetup(t *testing.T) {
 	tests := []struct {
-		name    string
-		store   Store
+		name      string
+		store     Store
 		verifiers []Verifier
-		wantErr bool
+		wantErr   bool
 	}{
 		{
-			name:    "Store is not set",
-			store:   nil,
+			name:      "Store is not set",
+			store:     nil,
 			verifiers: []Verifier{&mockVerifier{}},
-			wantErr: true,
+			wantErr:   true,
 		},
 		{
-			name:    "Verifiers are not set",
-			store:   &mockStore{},
+			name:      "Verifiers are not set",
+			store:     &mockStore{},
 			verifiers: nil,
-			wantErr: true,
+			wantErr:   true,
 		},
 		{
-			name:    "All components are set",
-			store:   &mockStore{},
+			name:      "All components are set",
+			store:     &mockStore{},
 			verifiers: []Verifier{&mockVerifier{}},
-			wantErr: false,
+			wantErr:   false,
 		},
 	}
 

--- a/executor_test.go
+++ b/executor_test.go
@@ -66,7 +66,7 @@ func (m *mockVerifier) Verify(ctx context.Context, opts *VerifyOptions) (*Verifi
 	if m.verifyResult == nil {
 		return &VerificationResult{}, errors.New("verify result not initialized")
 	}
-	if result, ok := m.verifyResult[opts.Artifact.Digest.String()]; ok {
+	if result, ok := m.verifyResult[opts.ArtifactDescriptor.Digest.String()]; ok {
 		return result, nil
 	}
 	return &VerificationResult{}, nil

--- a/verifier.go
+++ b/verifier.go
@@ -44,8 +44,8 @@ type Verifier interface {
 
 // VerifyOptions represents the options to verify a subject against an artifact.
 type VerifyOptions struct {
-	// ArtifactStore is the store to access the artifacts. Required.
-	ArtifactStore Store
+	// Store is the store to access the artifacts. Required.
+	Store Store
 
 	// Subject is the subject reference of the artifact being verified.
 	// Required.
@@ -55,8 +55,9 @@ type VerifyOptions struct {
 	// Required.
 	SubjectDescriptor ocispec.Descriptor
 
-	// Artifact is the descriptor of the artifact being verified against.
-	Artifact ocispec.Descriptor
+	// ArtifactDescriptor is the descriptor of the artifact being verified
+	// against. Required.
+	ArtifactDescriptor ocispec.Descriptor
 }
 
 // VerificationResult defines the verification result that a verifier plugin

--- a/verifier.go
+++ b/verifier.go
@@ -39,7 +39,24 @@ type Verifier interface {
 
 	// Verify verifies the subject in the store against the artifact and
 	// returns the verification result.
-	Verify(ctx context.Context, store Store, subject string, artifact ocispec.Descriptor) (*VerificationResult, error)
+	Verify(ctx context.Context, opts *VerifyOptions) (*VerificationResult, error)
+}
+
+// VerifyOptions represents the options to verify a subject against an artifact.
+type VerifyOptions struct {
+	// ArtifactStore is the store to access the artifacts. Required.
+	ArtifactStore Store
+
+	// Subject is the subject reference of the artifact being verified.
+	// Required.
+	Subject string
+
+	// SubjectDescriptor is the descriptor of the subject being verified.
+	// Required.
+	SubjectDescriptor ocispec.Descriptor
+
+	// Artifact is the descriptor of the artifact being verified against.
+	Artifact ocispec.Descriptor
 }
 
 // VerificationResult defines the verification result that a verifier plugin


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
1. Update Verifier interface to take `SubjectDescriptor` as input so that verifier does not need to resolve the subject again.
2. Update `Executor` workflow to set the `SubjectDescriptor` when invoking verifier.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Updated unit tests.

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
