### PR TITLE
feat: Implement threshold-based policy enforcer

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -43,11 +43,15 @@ const (
 
 // mockVerifier is a mock implementation of Verifier.
 type mockVerifier struct {
+	name string
 	verifiable   bool
 	verifyResult map[string]*VerificationResult
 }
 
 func (m *mockVerifier) Name() string {
+	if m.name != "" {
+		return m.name
+	}
 	return "mock-verifier-name"
 }
 

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -20,29 +20,22 @@ import "maps"
 // Set represents a generic set data structure using a map with empty structs.
 type Set[E comparable] map[E]struct{}
 
-// NewSet creates and returns a new Set initialized with the provided elements.
-func NewSet[E comparable](elems ...E) *Set[E] {
-	s := &Set[E]{}
+// New creates and returns a new Set initialized with the provided elements.
+func New[E comparable](elems ...E) Set[E] {
+	s := Set[E]{}
 	for _, e := range elems {
-		(*s)[e] = struct{}{}
+		s[e] = struct{}{}
 	}
 	return s
 }
 
 // Contains checks if the set contains the specified element.
-func (s *Set[E]) Contains(v E) bool {
-	_, ok := (*s)[v]
+func (s Set[E]) Contains(v E) bool {
+	_, ok := s[v]
 	return ok
 }
 
-// Add inserts one or more elements into the set.
-func (s *Set[E]) Add(elems ...E) {
-	for _, e := range elems {
-		(*s)[e] = struct{}{}
-	}
-}
-
-// Copy copies all elements from the source set into the current set.
-func (s *Set[E]) Copy(src *Set[E]) {
-	maps.Copy(*s, *src)
+// Union adds elements from another set to the current set.
+func (s Set[E]) Union(elems Set[E]) {
+	maps.Copy(s, elems)
 }

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -1,0 +1,48 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package set
+
+import "maps"
+
+// Set represents a generic set data structure using a map with empty structs.
+type Set[E comparable] map[E]struct{}
+
+// NewSet creates and returns a new Set initialized with the provided elements.
+func NewSet[E comparable](elems ...E) *Set[E] {
+	s := &Set[E]{}
+	for _, e := range elems {
+		(*s)[e] = struct{}{}
+	}
+	return s
+}
+
+// Contains checks if the set contains the specified element.
+func (s *Set[E]) Contains(v E) bool {
+	_, ok := (*s)[v]
+	return ok
+}
+
+// Add inserts one or more elements into the set.
+func (s *Set[E]) Add(elems ...E) {
+	for _, e := range elems {
+		(*s)[e] = struct{}{}
+	}
+}
+
+// Copy copies all elements from the source set into the current set.
+func (s *Set[E]) Copy(src *Set[E]) {
+	maps.Copy(*s, *src)
+}

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package set
+
+import (
+	"testing"
+)
+
+func TestSetContains(t *testing.T) {
+	s := NewSet("a", "b", "c")
+	tests := []struct {
+		elem     string
+		expected bool
+	}{
+		{"a", true},
+		{"b", true},
+		{"x", false},
+	}
+
+	for _, tt := range tests {
+		if got := s.Contains(tt.elem); got != tt.expected {
+			t.Errorf("Contains(%q) = %v, want %v", tt.elem, got, tt.expected)
+		}
+	}
+}
+
+func TestSetAdd(t *testing.T) {
+	s := NewSet[int]()
+	s.Add(1, 2, 3)
+	if len(*s) != 3 {
+		t.Errorf("Add() expected length 3, got %d", len(*s))
+	}
+	s.Add(3, 4)
+	if len(*s) != 4 {
+		t.Errorf("Add() expected length 4 after adding duplicate, got %d", len(*s))
+	}
+	if !s.Contains(4) {
+		t.Errorf("Add() missing element 4 after adding")
+	}
+}
+
+func TestSetCopy(t *testing.T) {
+	src := NewSet(1, 2, 3)
+	dest := NewSet[int]()
+	dest.Copy(src)
+
+	if len(*dest) != len(*src) {
+		t.Errorf("Copy() expected length %d, got %d", len(*src), len(*dest))
+	}
+
+	for k := range *src {
+		if !dest.Contains(k) {
+			t.Errorf("Copy() missing element %d in destination set", k)
+		}
+	}
+}
+
+func TestSetEmpty(t *testing.T) {
+	s := NewSet[int]()
+	if len(*s) != 0 {
+		t.Errorf("NewSet() expected empty set, got length %d", len(*s))
+	}
+	if s.Contains(1) {
+		t.Errorf("Empty set should not contain any elements")
+	}
+}
+
+func TestSetAddDuplicate(t *testing.T) {
+	s := NewSet("a")
+	s.Add("a", "a")
+	if len(*s) != 1 {
+		t.Errorf("Add() expected length 1 after adding duplicates, got %d", len(*s))
+	}
+}

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -19,8 +19,20 @@ import (
 	"testing"
 )
 
+func TestNewSet(t *testing.T) {
+	s := New(1, 2, 3)
+	if len(s) != 3 {
+		t.Errorf("expected set length 3, got %d", len(s))
+	}
+	for _, v := range []int{1, 2, 3} {
+		if !s.Contains(v) {
+			t.Errorf("expected set to contain %d", v)
+		}
+	}
+}
+
 func TestSetContains(t *testing.T) {
-	s := NewSet("a", "b", "c")
+	s := New("a", "b", "c")
 	tests := []struct {
 		elem     string
 		expected bool
@@ -32,56 +44,46 @@ func TestSetContains(t *testing.T) {
 
 	for _, tt := range tests {
 		if got := s.Contains(tt.elem); got != tt.expected {
-			t.Errorf("Contains(%q) = %v, want %v", tt.elem, got, tt.expected)
+			t.Errorf("Contains(%q) = %v; want %v", tt.elem, got, tt.expected)
 		}
 	}
 }
 
 func TestSetAdd(t *testing.T) {
-	s := NewSet[int]()
-	s.Add(1, 2, 3)
-	if len(*s) != 3 {
-		t.Errorf("Add() expected length 3, got %d", len(*s))
-	}
-	s.Add(3, 4)
-	if len(*s) != 4 {
-		t.Errorf("Add() expected length 4 after adding duplicate, got %d", len(*s))
-	}
-	if !s.Contains(4) {
-		t.Errorf("Add() missing element 4 after adding")
-	}
-}
+	s1 := New(1, 2)
+	s2 := New(2, 3, 4)
 
-func TestSetCopy(t *testing.T) {
-	src := NewSet(1, 2, 3)
-	dest := NewSet[int]()
-	dest.Copy(src)
+	s1.Union(s2)
 
-	if len(*dest) != len(*src) {
-		t.Errorf("Copy() expected length %d, got %d", len(*src), len(*dest))
-	}
-
-	for k := range *src {
-		if !dest.Contains(k) {
-			t.Errorf("Copy() missing element %d in destination set", k)
+	expectedElems := []int{1, 2, 3, 4}
+	for _, v := range expectedElems {
+		if !s1.Contains(v) {
+			t.Errorf("expected set to contain %d after Add", v)
 		}
 	}
+
+	if len(s1) != 4 {
+		t.Errorf("expected set length 4 after Add, got %d", len(s1))
+	}
 }
 
-func TestSetEmpty(t *testing.T) {
-	s := NewSet[int]()
-	if len(*s) != 0 {
-		t.Errorf("NewSet() expected empty set, got length %d", len(*s))
+func TestEmptySet(t *testing.T) {
+	s := New[int]()
+	if len(s) != 0 {
+		t.Errorf("expected empty set length 0, got %d", len(s))
 	}
 	if s.Contains(1) {
-		t.Errorf("Empty set should not contain any elements")
+		t.Errorf("expected empty set not to contain any elements")
 	}
 }
 
-func TestSetAddDuplicate(t *testing.T) {
-	s := NewSet("a")
-	s.Add("a", "a")
-	if len(*s) != 1 {
-		t.Errorf("Add() expected length 1 after adding duplicates, got %d", len(*s))
+func TestAddEmptySet(t *testing.T) {
+	s1 := New(1, 2)
+	s2 := New[int]()
+
+	s1.Union(s2)
+
+	if len(s1) != 2 {
+		t.Errorf("expected set length 2 after adding empty set, got %d", len(s1))
 	}
 }

--- a/policyenforcer.go
+++ b/policyenforcer.go
@@ -21,6 +21,20 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+// PolicyDecision is the decision made by the policy enforcer.
+type PolicyDecision int
+
+const (
+	// PolicyDecisionUndetermined is the initial or a temporary state of the 
+	// policy decision.
+	PolicyDecisionUndetermined PolicyDecision = iota
+	// PolicyDecisionDeny is the final state when the policy evaluation failed.
+	PolicyDecisionDeny
+	// PolicyDecisionAllow is the final state when the policy evaluation 
+	// succeeded.
+	PolicyDecisionAllow
+)
+
 // PrunedState is the state how an artifact is pruned from the evaluation graph.
 type PrunedState int
 

--- a/policyenforcer.go
+++ b/policyenforcer.go
@@ -21,20 +21,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// PolicyDecision is the decision made by the policy enforcer.
-type PolicyDecision int
-
-const (
-	// PolicyDecisionUndetermined is the initial or a temporary state of the 
-	// policy decision.
-	PolicyDecisionUndetermined PolicyDecision = iota
-	// PolicyDecisionDeny is the final state when the policy evaluation failed.
-	PolicyDecisionDeny
-	// PolicyDecisionAllow is the final state when the policy evaluation 
-	// succeeded.
-	PolicyDecisionAllow
-)
-
 // PrunedState is the state how an artifact is pruned from the evaluation graph.
 type PrunedState int
 

--- a/threshold_policy_enforcer.go
+++ b/threshold_policy_enforcer.go
@@ -1,0 +1,466 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratify
+
+import (
+	"context"
+	"fmt"
+)
+
+const allRule = 0 // All nested rules must succeed for this rule to be allowed.
+
+// PolicyRule defines the policy rule for [ThresholdPolicyEnforcer].
+type PolicyRule struct {
+	// Verifier is the Verifier to be used for this rule.
+	// If set, the rule requires the Verifier to verify the corresponding
+	// artifact. Either Verifier or Rules must be set.
+	// Optional.
+	Verifier string
+
+	// Threshold is the required number of satisfied nested rules defined in
+	// this rule. If not set or set to 0, all nested rules must be satisfied.
+	// Optional.
+	Threshold int
+
+	// Rules hold nested rules that could be applied to referrer artifacts.
+	// Optional.
+	Rules []*PolicyRule
+
+	// verifiers hold the verifiers that are available in the nested rules with
+	// Verifier set. It's auto generated during the compilation of the policy.
+	verifiers map[string]struct{}
+
+	// ruleID is the unique ID of the rule in the policy tree. It's auto
+	// generatd during the compilation of the policy.
+	ruleID int
+}
+
+// evaluationNode holds the statistics for a policy rule during evaluation.
+// An evaluationNode is regarded as a virtual node if it corresponds to a rule
+// without Verifier set.
+type evaluationNode struct {
+	// rule is the policy rule for this node.
+	rule *PolicyRule
+
+	// subjectNode is the parent node of this node.
+	subjectNode *evaluationNode
+
+	// artifactDigest is the digest of the artifact being verified against in
+	// this node.
+	artifactDigest string
+
+	// ruleDecision indicates the decision made by the nested rules and the
+	// threshold. If there is no nested rules, this field is set to Allow by
+	// default.
+	ruleDecision PolicyDecision
+
+	// childVirtualNodes is the index of the immediate virtual evaluation
+	// nodes by rule ID.
+	childVirtualNodes map[int]*evaluationNode
+
+	// childNodes is the index of the immediate evaluation nodes with Verifers
+	// by rule ID.
+	childNodes map[int][]*evaluationNode
+
+	// commited indicates whether the node is commited or not.
+	commited bool
+}
+
+func (n *evaluationNode) addChildNode(rule *PolicyRule, artifactDigest string) *evaluationNode {
+	node := &evaluationNode{
+		rule:           rule,
+		subjectNode:    n,
+		artifactDigest: artifactDigest,
+	}
+	if len(rule.Rules) == 0 {
+		node.ruleDecision = PolicyDecisionAllow
+	} else {
+		node.childNodes = make(map[int][]*evaluationNode)
+		node.childVirtualNodes = make(map[int]*evaluationNode)
+	}
+
+	n.childNodes[rule.ruleID] = append(n.childNodes[rule.ruleID], node)
+	return node
+}
+
+func (n *evaluationNode) addChildVirtualNode(rule *PolicyRule) *evaluationNode {
+	node := &evaluationNode{
+		rule:        rule,
+		subjectNode: n,
+	}
+	node.childNodes = make(map[int][]*evaluationNode)
+	node.childVirtualNodes = make(map[int]*evaluationNode)
+
+	n.childVirtualNodes[rule.ruleID] = node
+	return node
+}
+
+// refreshDecision refreshes the decision for the node and its ancestors.
+func (n *evaluationNode) refreshDecision() {
+	// 1. Calculate rule decision.
+	if n.calculateDecision() == PolicyDecisionAllow {
+		// 2. If the rule decision is allow, propagate it to ancestors.
+		n.refreshAncestorsDecision()
+	}
+}
+
+// calculateDecision calculates the decision for the node based on the gathered
+// results.
+func (n *evaluationNode) calculateDecision() PolicyDecision {
+	if n.ruleDecision != PolicyDecisionUndetermined {
+		return n.ruleDecision
+	}
+
+	successfulRuleCount := 0
+	for _, nodes := range n.childNodes {
+		// validate each rule
+		for _, node := range nodes {
+			if node.ruleDecision == PolicyDecisionAllow {
+				successfulRuleCount++
+				break
+			}
+		}
+	}
+	for _, node := range n.childVirtualNodes {
+		if node.ruleDecision == PolicyDecisionAllow {
+			successfulRuleCount++
+		}
+	}
+
+	threshold := n.rule.Threshold
+	if threshold == allRule {
+		threshold = len(n.rule.Rules)
+	}
+	if successfulRuleCount >= threshold {
+		n.ruleDecision = PolicyDecisionAllow
+	}
+	if n.isCommited() {
+		n.ruleDecision = PolicyDecisionDeny
+	}
+	return n.ruleDecision
+}
+
+// isCommited checks if the node or any of its ancestors are commited.
+// In single goroutine mode, we only need to check the commited field.
+// In multi goroutine mode, we need to track referrers listed before committed.
+func (n *evaluationNode) isCommited() bool {
+	node := n
+	for node != nil {
+		if node.commited {
+			return true
+		}
+		node = node.subjectNode
+	}
+	return false
+}
+
+// refreshAncestorsDecision refreshes the decision for all ancestors.
+func (n *evaluationNode) refreshAncestorsDecision() {
+	node := n.subjectNode
+	for node != nil {
+		if node.ruleDecision != PolicyDecisionUndetermined {
+			break
+		}
+		// only propagate allow decision to ancestors.
+		if node.calculateDecision() != PolicyDecisionAllow {
+			break
+		}
+		node = node.subjectNode
+	}
+}
+
+// A node is finalized if either it's determined or any of its ancestors is
+// determined.
+func (n *evaluationNode) finalized() bool {
+	node := n
+	for node != nil {
+		if node.ruleDecision != PolicyDecisionUndetermined {
+			return true
+		}
+		node = node.subjectNode
+	}
+	return false
+}
+
+// verifiable checks if the verifier is required in the rule.
+func (n *evaluationNode) verifiable(verifier string) bool {
+	_, ok := n.rule.verifiers[verifier]
+	return ok
+}
+
+// thresholdEvaluator represents the state of the threshold policy during
+// evaluation.
+type thresholdEvaluator struct {
+	// evalGraph is the root node of the evaluation graph.
+	evalGraph *evaluationNode
+
+	// subjectIndex is the index of the evaluation nodes by subject digest.
+	subjectIndex map[string][]*evaluationNode
+
+	// verifierIndex is the index of the evaluation nodes by concatenating subject
+	// digest, artifact digest and verifier.
+	verifierIndex map[string][]*evaluationNode
+}
+
+// verifierIndexKey generates the key for the verifier index.
+func verifierIndexKey(subjectDigest, artifactDigest, verifier string) string {
+	return fmt.Sprintf("%s:%s:%s", subjectDigest, artifactDigest, verifier)
+}
+
+// Pruned checks if whether the verifier is required to verify the subject
+// against the artifact.
+func (e *thresholdEvaluator) Pruned(ctx context.Context, subjectDigest, artifactDigest, verifier string) (PrunedState, error) {
+	if _, ok := e.verifierIndex[verifierIndexKey(subjectDigest, artifactDigest, verifier)]; ok {
+		return PrunedStateVerifierPruned, nil
+	}
+	nodes, ok := e.subjectIndex[subjectDigest]
+	if !ok {
+		return PrunedStateNone, fmt.Errorf("no applicable policy rule defined for the subject %s", subjectDigest)
+	}
+
+	// Return PrunedStateSubjectPruned if all nodes are finalized.
+	// Otherwise, return PrunedStateVerifierPruned if all nodes don't require
+	// the verifier.
+	// Otherwise, return PrunedStateNone.
+	subjectPruned := true
+	verifierPruned := true
+	for _, node := range nodes {
+		if node.finalized() {
+			continue
+		}
+		subjectPruned = false
+		if node.verifiable(verifier) {
+			verifierPruned = false
+			break
+		}
+	}
+	if subjectPruned {
+		return PrunedStateSubjectPruned, nil
+	}
+	if verifierPruned {
+		return PrunedStateVerifierPruned, nil
+	}
+	return PrunedStateNone, nil
+}
+
+// AddResult adds the successful verification result of the subject against the
+// artifact to the evaluator for further evaluation.
+func (e *thresholdEvaluator) AddResult(ctx context.Context, subjectDigest, artifactDigest string, artifactResult *VerificationResult) error {
+	if artifactResult.Err != nil {
+		// Only add successful verification result to the evaluator.
+		return nil
+	}
+
+	nodes, err := e.createEvaluationNodes(subjectDigest, artifactDigest, artifactResult.Verifier.Name())
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodes {
+		node.refreshDecision()
+	}
+	return nil
+}
+
+// createEvaluationNodes creates new evaluation nodes for the given subject,
+// artifact and verifier.
+// Note that multiple nodes may be created in terms of the policy rules.
+func (e *thresholdEvaluator) createEvaluationNodes(subjectDigest, artifactDigest, verifier string) ([]*evaluationNode, error) {
+	// Find subject nodes for the given subject digest.
+	subjectNodes, ok := e.subjectIndex[subjectDigest]
+	if !ok {
+		return nil, fmt.Errorf("cannot find evaluation node for subject %s", subjectDigest)
+	}
+
+	// create new nodes for the combination of subject, artifact and verifier.
+	var nodes []*evaluationNode
+	for _, subjectNode := range subjectNodes {
+		newNodes := e.createEvaluationNodesForSubject(subjectDigest, artifactDigest, verifier, subjectNode)
+		if len(newNodes) > 0 {
+			nodes = append(nodes, newNodes...)
+		}
+	}
+	return nodes, nil
+}
+
+func (e *thresholdEvaluator) createEvaluationNodesForSubject(subjectDigest, artifactDigest, verifier string, subjectNode *evaluationNode) []*evaluationNode {
+	var nodes []*evaluationNode
+	for _, rule := range subjectNode.rule.Rules {
+		if rule.Verifier != "" {
+			nodes = e.createEvaluationNode(rule, subjectDigest, artifactDigest, verifier, subjectNode, nodes)
+		} else {
+			nodes = e.createVirtualEvaluationNode(rule, subjectDigest, artifactDigest, verifier, subjectNode, nodes)
+		}
+	}
+	return nodes
+}
+
+func (e *thresholdEvaluator) createEvaluationNode(rule *PolicyRule, subjectDigest, artifactDigest, verifier string, subjectNode *evaluationNode, nodes []*evaluationNode) []*evaluationNode {
+	if verifier != rule.Verifier {
+		return nodes
+	}
+
+	node := subjectNode.addChildNode(rule, artifactDigest)
+	nodes = append(nodes, node)
+
+	verifierIndexKey := verifierIndexKey(subjectDigest, artifactDigest, verifier)
+	e.verifierIndex[verifierIndexKey] = append(e.verifierIndex[verifierIndexKey], node)
+	e.subjectIndex[artifactDigest] = append(e.subjectIndex[artifactDigest], node)
+
+	return nodes
+}
+
+func (e *thresholdEvaluator) createVirtualEvaluationNode(rule *PolicyRule, subjectDigest, artifactDigest, verifier string, subjectNode *evaluationNode, nodes []*evaluationNode) []*evaluationNode {
+	if _, ok := rule.verifiers[verifier]; !ok {
+		return nodes
+	}
+
+	node, ok := subjectNode.childVirtualNodes[rule.ruleID]
+	if !ok {
+		node = subjectNode.addChildVirtualNode(rule)
+	}
+
+	newNodes := e.createEvaluationNodesForSubject(subjectDigest, artifactDigest, verifier, node)
+	if len(newNodes) > 0 {
+		nodes = append(nodes, newNodes...)
+	}
+	return nodes
+}
+
+// Commit marks related nodes as commited.
+// In single goroutine mode, refresh commited nodes to calculate the decision.
+// In multi goroutine mode, commited node cannot be refreshed as it may need
+// more verification results to make a decision.
+func (e *thresholdEvaluator) Commit(ctx context.Context, subjectDigest string) error {
+	nodes, ok := e.subjectIndex[subjectDigest]
+	if !ok {
+		return fmt.Errorf("subject: %s has not been processed yet", subjectDigest)
+	}
+	for _, node := range nodes {
+		node.commited = true
+		node.refreshDecision()
+	}
+	return nil
+}
+
+// Evaluate makes the final decision based on aggregated evaluation graph.
+func (e *thresholdEvaluator) Evaluate(ctx context.Context) (bool, error) {
+	// Refresh the decision for the root node.
+	e.evalGraph.refreshDecision()
+	return e.evalGraph.ruleDecision == PolicyDecisionAllow, nil
+}
+
+// ThresholdPolicyEnforcer is an implementation of the PolicyEnforcer interface.
+type ThresholdPolicyEnforcer struct {
+	policy *PolicyRule
+}
+
+// NewThresholdPolicyEnforcer creates a new ThresholdPolicyEnforcer with the
+// given policy rule. The policy rule must be non-nil.
+func NewThresholdPolicyEnforcer(policy *PolicyRule) (*ThresholdPolicyEnforcer, error) {
+	if err := validatePolicy(policy); err != nil {
+		return nil, err
+	}
+	
+	return &ThresholdPolicyEnforcer{
+		policy: compilePolicy(policy),
+	}, nil
+}
+
+func validatePolicy(policy *PolicyRule) error {
+	if policy == nil {
+		return fmt.Errorf("policy rule is nil")
+	}
+	if policy.Verifier != "" {
+		return fmt.Errorf("the root rule must not have a verifier name")
+	}
+
+	return validateRule(policy)
+}
+
+func validateRule(rule *PolicyRule) error {
+	if rule == nil {
+		return fmt.Errorf("rule is nil")
+	}
+
+	// Validate threshold value.
+	if rule.Threshold < 0 {
+		return fmt.Errorf("threshold must be greater than or equal to 0")
+	}
+	if rule.Threshold > len(rule.Rules) {
+		return fmt.Errorf("threshold must be less than or equal to the number of rules")
+	}
+
+	if rule.Verifier == "" && len(rule.Rules) == 0 {
+		return fmt.Errorf("rule must have at least one nested rule if no verifier name is set")
+	}
+
+	for _, childRule := range rule.Rules {
+		if err := validateRule(childRule); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// compilePolicy compiles the plain policy into a policy that can be used for
+// evaluation directly.
+func compilePolicy(policy *PolicyRule) *PolicyRule {
+	initRuleID := 1
+	_ = updateRules(policy, &initRuleID)
+	return policy
+}
+
+func updateRules(policy *PolicyRule, ruleID *int) map[string]struct{} {
+	policy.ruleID = *ruleID
+	*ruleID++
+
+	verifiers := make(map[string]struct{})
+	for _, childRule := range policy.Rules {
+		childVerifiers := updateRules(childRule, ruleID)
+		for verifier := range childVerifiers {
+			verifiers[verifier] = struct{}{}
+		}
+	}
+	policy.verifiers = verifiers
+
+	if policy.Verifier != "" {
+		return map[string]struct{}{policy.Verifier: {}}
+	}
+	return verifiers
+}
+
+// Evaluator returns a thresholdEvaluator for the given subject digest.
+func (e *ThresholdPolicyEnforcer) Evaluator(ctx context.Context, subjectDigest string) (Evaluator, error) {
+	if e.policy == nil {
+		return nil, fmt.Errorf("policy is nil")
+	}
+
+	rootNode := &evaluationNode{
+		rule:              e.policy,
+		artifactDigest:    subjectDigest,
+		childNodes:        make(map[int][]*evaluationNode),
+		childVirtualNodes: make(map[int]*evaluationNode),
+	}
+
+	return &thresholdEvaluator{
+		subjectIndex: map[string][]*evaluationNode{
+			subjectDigest: {rootNode},
+		},
+		verifierIndex: make(map[string][]*evaluationNode),
+		evalGraph:     rootNode,
+	}, nil
+}

--- a/threshold_policy_enforcer_test.go
+++ b/threshold_policy_enforcer_test.go
@@ -43,7 +43,7 @@ const (
 func TestNewThresholdPolicyEnforcer(t *testing.T) {
 	tests := []struct {
 		name        string
-		policy      *PolicyRule
+		policy      *ThresholdPolicyRule
 		expectError bool
 	}{
 		{
@@ -53,9 +53,9 @@ func TestNewThresholdPolicyEnforcer(t *testing.T) {
 		},
 		{
 			name: "valid policy with nested rules",
-			policy: &PolicyRule{
+			policy: &ThresholdPolicyRule{
 				Threshold: 1,
-				Rules: []*PolicyRule{
+				Rules: []*ThresholdPolicyRule{
 					{Verifier: "verifier1"},
 					{Verifier: "verifier2"},
 				},
@@ -64,16 +64,16 @@ func TestNewThresholdPolicyEnforcer(t *testing.T) {
 		},
 		{
 			name: "invalid policy with verifier name at root",
-			policy: &PolicyRule{
+			policy: &ThresholdPolicyRule{
 				Verifier: "rootVerifier",
 			},
 			expectError: true,
 		},
 		{
 			name: "invalid policy with negative threshold",
-			policy: &PolicyRule{
+			policy: &ThresholdPolicyRule{
 				Threshold: -1,
-				Rules: []*PolicyRule{
+				Rules: []*ThresholdPolicyRule{
 					{Verifier: "verifier1"},
 				},
 			},
@@ -81,9 +81,9 @@ func TestNewThresholdPolicyEnforcer(t *testing.T) {
 		},
 		{
 			name: "invalid policy with threshold greater than rules count",
-			policy: &PolicyRule{
+			policy: &ThresholdPolicyRule{
 				Threshold: 3,
-				Rules: []*PolicyRule{
+				Rules: []*ThresholdPolicyRule{
 					{Verifier: "verifier1"},
 					{Verifier: "verifier2"},
 				},
@@ -92,7 +92,7 @@ func TestNewThresholdPolicyEnforcer(t *testing.T) {
 		},
 		{
 			name: "invalid policy with no verifier and no nested rules",
-			policy: &PolicyRule{
+			policy: &ThresholdPolicyRule{
 				Threshold: 0,
 			},
 			expectError: true,
@@ -115,9 +115,9 @@ func TestNewThresholdPolicyEnforcer(t *testing.T) {
 	}
 }
 func TestThresholdPolicyEnforcer_Evaluator(t *testing.T) {
-	validPolicy := &PolicyRule{
+	validPolicy := &ThresholdPolicyRule{
 		Threshold: 1,
-		Rules: []*PolicyRule{
+		Rules: []*ThresholdPolicyRule{
 			{Verifier: "verifier1"},
 			{Verifier: "verifier2"},
 		},
@@ -194,24 +194,24 @@ func TestEvaluation(t *testing.T) {
 	//         - verifier: sbom-verifier-3
 	//           rules:
 	//             - verifier: cosign-verifier-1
-	policy := &PolicyRule{
+	policy := &ThresholdPolicyRule{
 		Threshold: 2,
-		Rules: []*PolicyRule{
+		Rules: []*ThresholdPolicyRule{
 			{
 				Verifier: notationVerifier1,
 			},
 			{
 				Verifier: sbomVerifier1,
-				Rules: []*PolicyRule{
+				Rules: []*ThresholdPolicyRule{
 					{
 						Verifier: notationVerifier1,
 					},
 					{
 						Threshold: 1,
-						Rules: []*PolicyRule{
+						Rules: []*ThresholdPolicyRule{
 							{
 								Verifier: sbomVerifier3,
-								Rules: []*PolicyRule{
+								Rules: []*ThresholdPolicyRule{
 									{
 										Verifier: notationVerifier1,
 									},
@@ -219,7 +219,7 @@ func TestEvaluation(t *testing.T) {
 							},
 							{
 								Verifier: sbomVerifier4,
-								Rules: []*PolicyRule{
+								Rules: []*ThresholdPolicyRule{
 									{
 										Verifier: notationVerifier1,
 									},
@@ -229,10 +229,10 @@ func TestEvaluation(t *testing.T) {
 					},
 					{
 						Threshold: 1,
-						Rules: []*PolicyRule{
+						Rules: []*ThresholdPolicyRule{
 							{
 								Verifier: sbomVerifier3,
-								Rules: []*PolicyRule{
+								Rules: []*ThresholdPolicyRule{
 									{
 										Verifier: notationVerifier1,
 									},
@@ -240,7 +240,7 @@ func TestEvaluation(t *testing.T) {
 							},
 							{
 								Verifier: sbomVerifier5,
-								Rules: []*PolicyRule{
+								Rules: []*ThresholdPolicyRule{
 									{
 										Verifier: notationVerifier1,
 									},
@@ -252,13 +252,13 @@ func TestEvaluation(t *testing.T) {
 			},
 			{
 				Verifier: sbomVerifier2,
-				Rules: []*PolicyRule{
+				Rules: []*ThresholdPolicyRule{
 					{
 						Verifier: cosignVerifier1,
 					},
 					{
 						Verifier: sbomVerifier1,
-						Rules: []*PolicyRule{
+						Rules: []*ThresholdPolicyRule{
 							{
 								Verifier: cosignVerifier1,
 							},

--- a/threshold_policy_enforcer_test.go
+++ b/threshold_policy_enforcer_test.go
@@ -1,0 +1,405 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratify
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+const (
+	imageDigest       = "image-digest"
+	notationDigest1   = "notation-digest-1"
+	notationDigest2   = "notation-digest-2"
+	notationDigest3   = "notation-digest-3"
+	notationDigest4   = "notation-digest-4"
+	sbomDigest1       = "sbom-digest-1"
+	sbomDigest2       = "sbom-digest-2"
+	sbomDigest3       = "sbom-digest-3"
+	sbomVerifier1     = "sbom-verifier-1"
+	sbomVerifier2     = "sbom-verifier-2"
+	sbomVerifier3     = "sbom-verifier-3"
+	sbomVerifier4     = "sbom-verifier-4"
+	sbomVerifier5     = "sbom-verifier-5"
+	notationVerifier1 = "notation-verifier-1"
+	notationVerifier2 = "notation-verifier-2"
+	cosignVerifier1   = "cosign-verifier-1"
+)
+
+func TestNewThresholdPolicyEnforcer(t *testing.T) {
+	tests := []struct {
+		name        string
+		policy      *PolicyRule
+		expectError bool
+	}{
+		{
+			name:        "nil policy",
+			policy:      nil,
+			expectError: true,
+		},
+		{
+			name: "valid policy with nested rules",
+			policy: &PolicyRule{
+				Threshold: 1,
+				Rules: []*PolicyRule{
+					{Verifier: "verifier1"},
+					{Verifier: "verifier2"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid policy with verifier name at root",
+			policy: &PolicyRule{
+				Verifier: "rootVerifier",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid policy with negative threshold",
+			policy: &PolicyRule{
+				Threshold: -1,
+				Rules: []*PolicyRule{
+					{Verifier: "verifier1"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid policy with threshold greater than rules count",
+			policy: &PolicyRule{
+				Threshold: 3,
+				Rules: []*PolicyRule{
+					{Verifier: "verifier1"},
+					{Verifier: "verifier2"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid policy with no verifier and no nested rules",
+			policy: &PolicyRule{
+				Threshold: 0,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enforcer, err := NewThresholdPolicyEnforcer(tt.policy)
+			if tt.expectError && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !tt.expectError && enforcer == nil {
+				t.Errorf("expected enforcer to be non-nil")
+			}
+		})
+	}
+}
+func TestThresholdPolicyEnforcer_Evaluator(t *testing.T) {
+	validPolicy := &PolicyRule{
+		Threshold: 1,
+		Rules: []*PolicyRule{
+			{Verifier: "verifier1"},
+			{Verifier: "verifier2"},
+		},
+	}
+
+	enforcer, err := NewThresholdPolicyEnforcer(validPolicy)
+	if err != nil {
+		t.Fatalf("unexpected error creating enforcer: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		policyEnforcer *ThresholdPolicyEnforcer
+		subjectDigest  string
+		expectError    bool
+	}{
+		{
+			name:           "valid evaluator creation",
+			policyEnforcer: enforcer,
+			subjectDigest:  "digest1",
+			expectError:    false,
+		},
+		{
+			name:           "nil policy enforcer",
+			policyEnforcer: &ThresholdPolicyEnforcer{policy: nil},
+			subjectDigest:  "digest2",
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluator, err := tt.policyEnforcer.Evaluator(context.Background(), tt.subjectDigest)
+			if tt.expectError && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !tt.expectError && evaluator == nil {
+				t.Errorf("expected evaluator to be non-nil")
+			}
+		})
+	}
+}
+
+func TestEvaluation(t *testing.T) {
+	// The testing policy can be represented in yaml as:
+	// - threshold: 2
+	//   rules:
+	//     - verifier: notation-verifier-1
+	//     - verifier: sbom-verifier-1
+	//       rules:
+	//         - verifier: notation-verifier-1
+	//         - threshold: 1
+	//		     rules:
+	//         	   - verifier: sbom-verifier-3
+	//           	 rules:
+	//             	   - verifier: notation-verifier-1
+	//             - verifier: sbom-verifier-4
+	//               rules:
+	//                 - verifier: notation-verifier-1
+	//          - threshold: 1
+	//		     rules:
+	//         	   - verifier: sbom-verifier-3
+	//           	 rules:
+	//             	   - verifier: notation-verifier-1
+	//             - verifier: sbom-verifier-5
+	//               rules:
+	//                 - verifier: notation-verifier-1
+	//     - verifier: sbom-verifier-2
+	//       rules:
+	//         - verifier: cosign-verifier-1
+	//         - verifier: sbom-verifier-3
+	//           rules:
+	//             - verifier: cosign-verifier-1
+	policy := &PolicyRule{
+		Threshold: 2,
+		Rules: []*PolicyRule{
+			{
+				Verifier: notationVerifier1,
+			},
+			{
+				Verifier: sbomVerifier1,
+				Rules: []*PolicyRule{
+					{
+						Verifier: notationVerifier1,
+					},
+					{
+						Threshold: 1,
+						Rules: []*PolicyRule{
+							{
+								Verifier: sbomVerifier3,
+								Rules: []*PolicyRule{
+									{
+										Verifier: notationVerifier1,
+									},
+								},
+							},
+							{
+								Verifier: sbomVerifier4,
+								Rules: []*PolicyRule{
+									{
+										Verifier: notationVerifier1,
+									},
+								},
+							},
+						},
+					},
+					{
+						Threshold: 1,
+						Rules: []*PolicyRule{
+							{
+								Verifier: sbomVerifier3,
+								Rules: []*PolicyRule{
+									{
+										Verifier: notationVerifier1,
+									},
+								},
+							},
+							{
+								Verifier: sbomVerifier5,
+								Rules: []*PolicyRule{
+									{
+										Verifier: notationVerifier1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Verifier: sbomVerifier2,
+				Rules: []*PolicyRule{
+					{
+						Verifier: cosignVerifier1,
+					},
+					{
+						Verifier: sbomVerifier1,
+						Rules: []*PolicyRule{
+							{
+								Verifier: cosignVerifier1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// The image that will be tested against the policy is in the following
+	// structure:
+	// image-digest
+	// ├── notation-digest-1
+	// └── sbom-digest-1
+	//     ├── notation-digest-2
+	//     └── sbom-digest-2
+	//         └── notation-digest-3
+	enforcer, err := NewThresholdPolicyEnforcer(policy)
+	if err != nil {
+		t.Fatalf("unexpected error creating enforcer: %v", err)
+	}
+	ctx := context.Background()
+	evaluator, err := enforcer.Evaluator(ctx, imageDigest)
+	if err != nil {
+		t.Fatalf("unexpected error creating evaluator: %v", err)
+	}
+
+	if _, err = evaluator.Pruned(ctx, sbomDigest1, notationDigest1, notationVerifier1); err == nil {
+		t.Fatalf("expected error, got none")
+	}
+
+	state, err := evaluator.Pruned(ctx, imageDigest, notationDigest1, notationVerifier2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != PrunedStateVerifierPruned {
+		t.Fatalf("expected verifier pruned state, got %v", state)
+	}
+
+	state, err = evaluator.Pruned(ctx, imageDigest, notationDigest1, notationVerifier1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != PrunedStateNone {
+		t.Fatalf("expected none pruned state, got %v", state)
+	}
+
+	if err = evaluator.AddResult(ctx, imageDigest, notationDigest1, &VerificationResult{Err: errors.New("verification error")}); err != nil {
+		t.Fatalf("unexpected error adding result: %v", err)
+	}
+	if err = evaluator.AddResult(ctx, imageDigest, notationDigest1, &VerificationResult{Verifier: &mockVerifier{name: notationVerifier1}}); err != nil {
+		t.Fatalf("unexpected error adding result: %v", err)
+	}
+	decision, err := evaluator.Evaluate(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error evaluating: %v", err)
+	}
+	if decision != false {
+		t.Fatalf("expected decision false, got %v", decision)
+	}
+
+	state, err = evaluator.Pruned(ctx, imageDigest, sbomDigest1, sbomVerifier1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != PrunedStateNone {
+		t.Fatalf("expected none pruned state, got %v", state)
+	}
+	if err = evaluator.AddResult(ctx, imageDigest, sbomDigest1, &VerificationResult{Verifier: &mockVerifier{name: sbomVerifier1}}); err != nil {
+		t.Fatalf("unexpected error adding result: %v", err)
+	}
+	state, err = evaluator.Pruned(ctx, imageDigest, sbomDigest1, sbomVerifier1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != PrunedStateVerifierPruned {
+		t.Fatalf("expected verifier pruned state, got %v", state)
+	}
+
+	state, err = evaluator.Pruned(ctx, imageDigest, sbomDigest1, sbomVerifier2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != PrunedStateNone {
+		t.Fatalf("expected none pruned state, got %v", state)
+	}
+	if err = evaluator.AddResult(ctx, imageDigest, sbomDigest1, &VerificationResult{Verifier: &mockVerifier{name: sbomVerifier2}}); err != nil {
+		t.Fatalf("unexpected error adding result: %v", err)
+	}
+
+	state, err = evaluator.Pruned(ctx, sbomDigest1, notationDigest2, notationVerifier1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != PrunedStateNone {
+		t.Fatalf("expected none pruned state, got %v", state)
+	}
+	if err = evaluator.AddResult(ctx, sbomDigest1, notationDigest2, &VerificationResult{Verifier: &mockVerifier{name: notationVerifier1}}); err != nil {
+		t.Fatalf("unexpected error adding result: %v", err)
+	}
+
+	state, err = evaluator.Pruned(ctx, sbomDigest1, sbomDigest2, sbomVerifier3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != PrunedStateNone {
+		t.Fatalf("expected none pruned state, got %v", state)
+	}
+	if err = evaluator.AddResult(ctx, sbomDigest1, sbomDigest2, &VerificationResult{Verifier: &mockVerifier{name: sbomVerifier3}}); err != nil {
+		t.Fatalf("unexpected error adding result: %v", err)
+	}
+
+	state, err = evaluator.Pruned(ctx, sbomDigest2, notationDigest3, notationVerifier1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != PrunedStateNone {
+		t.Fatalf("expected none pruned state, got %v", state)
+	}
+	if err = evaluator.AddResult(ctx, sbomDigest2, notationDigest3, &VerificationResult{Verifier: &mockVerifier{name: notationVerifier1}}); err != nil {
+		t.Fatalf("unexpected error adding result: %v", err)
+	}
+
+	state, err = evaluator.Pruned(ctx, sbomDigest2, notationDigest4, notationVerifier1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != PrunedStateSubjectPruned {
+		t.Fatalf("expected subject pruned state, got %v", state)
+	}
+
+	decision, err = evaluator.Evaluate(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error evaluating: %v", err)
+	}
+	if decision != true {
+		t.Fatalf("expected decision true, got %v", decision)
+	}
+
+	if err = evaluator.Commit(ctx, imageDigest); err != nil {
+		t.Fatalf("unexpected error committing: %v", err)
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

### Intro
This PR implements a threshold-based policy enforcer. It implements both `Evaluator` and `PolicyEnforcer` interfaces.

### Policy Design
The new policy enforcer requires a new schema of config policy. The new Policy can be defined in both Json or Yaml format, but it will have different syntax from the one in v1. The new schema:
- Rule Object
  - verifier (string, optional)
    - The identifier for the verifier to be used in this rule.
  - threshold (integer, optional, default: 0)
    - Defines the minimum number of successful verifications required for nested rules to succeed.
  -  rules (array of Rule objects, optional)
     - A nested list of rules allowing hierarchical verification structures.

some examples:
```jsonc
// A policy requires an image was signed by either cosign or notation or both.
{
	"threshold": 1,
	"rules": [
		{
			"verifier": "notation-verifier-1"
		},
		{
			"verifier": "cosign-verifier-1"
		}
	]
}

// A policy requires an image was signed by notation and its sbom artifact was signed by notation as well.
{
	"threshold": 0,
	"rules": [
		{
			"verifier": "notation-verifier-1"
		},
		{
			"verifier": "sbom-verifier-1",
			"threshold": 0,
			"rules": [
				{
					"verifier": "notation-verifier-1"
				}
			]
		}
	]
}
```
Note: 0 threshold stands for ALL rule, which requires all nested rules MUST succeed.

### Structs Design
#### `PolicyRule`
`PolicyRule` contains 3 exposed fields:
- `Verifier` (string)
- `Threshold` (int)
- `Rules` ([]*PolicyRule)

and 2 internal fields that will be auto-generated during policy compilation:
- `verifiers` (map[string]struct{})
- `ruleID` (int)

#### `evaluationNode`
`evaluationNode` is the actual minimal unit to save temporary evaluation result for a verifier verifying a subject against an artifact. When we add a result to the evaluator, it will created new `evaluationNodes`. And by checking the status of `evaluationNodes`, evaluator will know if the new verification is required.

#### `thresholdEvaluator`
`thresholdEvaluator` implements `Evaluator` interface by constructing a tree consisting of `evaluationNodes`.

#### `ThresholdPolicyEnforcer`
`ThresholdPolicyEnforcer` implements `PolicyEnforcer` interface. It compiles the provided policy during initialization and creates a new `thresholdEvaluator` instance upon each validation request.

**Which issue(s) this PR resolves**

Resolves https://github.com/ratify-project/ratify-go/issues/22

**Please check the following list**:

- [x]  Does the affected code have corresponding tests, e.g. unit test?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?
