### PR TITLE
fix: remove subjectIndex check in Commit

### DIFF
--- a/threshold_policy_enforcer.go
+++ b/threshold_policy_enforcer.go
@@ -396,11 +396,7 @@ func (e *thresholdEvaluator) createVirtualEvaluationNode(rule *ThresholdPolicyRu
 // In multi goroutine mode, commited node cannot be refreshed as it may need
 // more verification results to make a decision.
 func (e *thresholdEvaluator) Commit(ctx context.Context, subjectDigest string) error {
-	nodes, ok := e.subjectIndex[subjectDigest]
-	if !ok {
-		return fmt.Errorf("subject: %s has not been processed yet", subjectDigest)
-	}
-	for _, node := range nodes {
+	for _, node := range e.subjectIndex[subjectDigest] {
 		node.commited = true
 		node.refreshDecision()
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

`Commit` API should just commit available nodes for given subject. If no nodes are found, it should just skip it instead of returning an error which breaks the overal evaluation.

Added unit test for this scenario.

**Which issue(s) this PR resolves**

<!-- Optional, in `resolves #<issue number>(, resolves #<issue_number>, ...)` format, will close the issue(s) when PR gets merged). -->

Resolves #

**Please check the following list**:

- [x]  Does the affected code have corresponding tests, e.g. unit test?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?
