### PR TITLE
fix: optimize executor by removing unnecessary work

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -185,6 +185,14 @@ func (e *Executor) verifySubjectAgainstReferrers(ctx context.Context, task *exec
 			if errors.Is(err, errSubjectPruned) {
 				return errSubjectPruned
 			}
+
+			if len(results) == 0 {
+				// If no results are generated, the artifact has no valid verifiers or is not configured
+				// in the policy enforcer. Therefore, its referrers will not influence the validation
+				// result of the subject artifact and can be skipped.
+				continue
+			}
+
 			referrerArtifact := task.artifact
 			referrerArtifact.Reference = referrer.Digest.String()
 			newTasks = append(newTasks, &executorTask{

--- a/executor_test.go
+++ b/executor_test.go
@@ -43,7 +43,7 @@ const (
 
 // mockVerifier is a mock implementation of Verifier.
 type mockVerifier struct {
-	name string
+	name         string
 	verifiable   bool
 	verifyResult map[string]*VerificationResult
 }
@@ -746,6 +746,10 @@ func TestValidateArtifact(t *testing.T) {
 						Digest: testDigest1,
 					},
 				},
+				// Referrers structure:
+				// testImage
+				//     ├──> testArtifact2 ─> testArtifact4 ─> testArtifact5
+				//     └──> testArtifact3
 				digestToReferrers: map[string][]ocispec.Descriptor{
 					testArtifact1: {
 						{
@@ -801,22 +805,10 @@ func TestValidateArtifact(t *testing.T) {
 						},
 						ArtifactReports: []*ValidationReport{},
 					},
+					// testArtifact2 is pruned, so it and its nested artifacts
+					// are not reported
 					{
-						ArtifactReports: []*ValidationReport{{
-							Results: []*VerificationResult{
-								{
-									Description: validMessage4,
-								},
-							},
-							ArtifactReports: []*ValidationReport{{
-								Results: []*VerificationResult{
-									{
-										Description: validMessage5,
-									},
-								},
-								ArtifactReports: []*ValidationReport{},
-							}},
-						}},
+						ArtifactReports: []*ValidationReport{},
 					},
 				}},
 			wantErr: false,

--- a/executor_test.go
+++ b/executor_test.go
@@ -660,6 +660,10 @@ func TestValidateArtifact(t *testing.T) {
 						Digest: testDigest1,
 					},
 				},
+				// Referrers structure:
+				// testImage
+				// ├──> testArtifact2 ─> testArtifact4 ─> testArtifact5
+				// └──> testArtifact3
 				digestToReferrers: map[string][]ocispec.Descriptor{
 					testArtifact1: {
 						{
@@ -716,21 +720,7 @@ func TestValidateArtifact(t *testing.T) {
 						ArtifactReports: []*ValidationReport{},
 					},
 					{
-						ArtifactReports: []*ValidationReport{{
-							Results: []*VerificationResult{
-								{
-									Description: validMessage4,
-								},
-							},
-							ArtifactReports: []*ValidationReport{{
-								Results: []*VerificationResult{
-									{
-										Description: validMessage5,
-									},
-								},
-								ArtifactReports: []*ValidationReport{},
-							}},
-						}},
+						ArtifactReports: []*ValidationReport{},
 					},
 				}},
 			wantErr: false,
@@ -748,8 +738,8 @@ func TestValidateArtifact(t *testing.T) {
 				},
 				// Referrers structure:
 				// testImage
-				//     ├──> testArtifact2 ─> testArtifact4 ─> testArtifact5
-				//     └──> testArtifact3
+				// ├──> testArtifact2 ─> testArtifact4 ─> testArtifact5
+				// └──> testArtifact3
 				digestToReferrers: map[string][]ocispec.Descriptor{
 					testArtifact1: {
 						{


### PR DESCRIPTION
## What this PR does / why we need it:
For example
```
image
     ├──> sig
     ├──> document ──> sig
     └──> sbom
```
If the `document` doesn't have a verifier, it should not affect the verification result of `image`. Therefore, we can skip the referrers for the `document`. This PR provides a solution to optimize it.

**Please check the following list**:

- [x]  Does the affected code have corresponding tests, e.g. unit test?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?
