### PR TITLE
fix: policy enforcer unknow subject node

### DIFF
--- a/threshold_policy_enforcer.go
+++ b/threshold_policy_enforcer.go
@@ -279,7 +279,7 @@ func (e *thresholdEvaluator) Pruned(ctx context.Context, subjectDigest, artifact
 	}
 	nodes, ok := e.subjectIndex[subjectDigest]
 	if !ok {
-		return PrunedStateNone, fmt.Errorf("no applicable policy rule defined for the subject %s", subjectDigest)
+		return PrunedStateSubjectPruned, nil
 	}
 
 	// Return PrunedStateSubjectPruned if all nodes are finalized.

--- a/threshold_policy_enforcer_test.go
+++ b/threshold_policy_enforcer_test.go
@@ -359,8 +359,8 @@ func TestEvaluation(t *testing.T) {
 		t.Fatalf("unexpected error creating evaluator: %v", err)
 	}
 
-	if _, err = evaluator.Pruned(ctx, sbomDigest1, notationDigest1, notationVerifier1); err == nil {
-		t.Fatalf("expected error, got none")
+	if state, err := evaluator.Pruned(ctx, sbomDigest1, notationDigest1, notationVerifier1); err != nil || state != PrunedStateSubjectPruned {
+		t.Fatalf("expected no error and subject pruned state, got error: %v, state: %v", err, state)
 	}
 
 	state, err := evaluator.Pruned(ctx, imageDigest, notationDigest1, notationVerifier2)


### PR DESCRIPTION
## What this PR does / why we need it:
Example referrer structure:
```
image
├──> sig1
└──> SBoM──> sig2
```
In this case, if there is no verifier configured for the SBoM, it will trigger an error when verifying sig2, as the subject (SBoM) cannot be found in the evaluation graph.

Resolves #65 

**Please check the following list**:

- [x]  Does the affected code have corresponding tests, e.g. unit test?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?
